### PR TITLE
Fix insertion handling in infernal2mapping

### DIFF
--- a/utils/infernal2mapping.py
+++ b/utils/infernal2mapping.py
@@ -97,8 +97,14 @@ def read_structures(f) -> List[SequenceStructureMapping]:
     # Non-bracket and non-alpha symbols correspond to gaps in sequence
     tgt_s_s_m.sq = sq.replace('-', '')
     # . and ~ symbols correspond to insertions with respect to template
-    tmp_s_s_m.str = str_temp_used.replace('.', '').replace('~', '')
     #tmp_full_s_s_m.str = copy.deepcopy(tmp_s_s_m.str)
+
+    tmp_s_s_m.str = ''
+    for nt, str_character in zip(sq, str_temp_used):
+        # if nt is lowercase AND str_character is . or ~, then it is an insertion, so skip it
+        if 'a' <= nt <= 'z' and str_character in '.~':
+            continue
+        tmp_s_s_m.str += str_character
 
     for i, letter in enumerate(sq):
         if letter != '-':


### PR DESCRIPTION
👋 @davidhoksza Hi David! Hope all is well! 

This pull request fixes the problems that @nawrockie was running into with R2DT when unpaired nucleotides were not positioned properly. This was happening because the Infernal mapping was crashing and R2DT was falling back on Traveler's default mapping between the target and the template.

The reason the Infernal mapping script was failing was because the insertions were handled incorrectly. Previously, the script replaced all `.` and `~` characters in the secondary structure line, but not all `.` characters were insertions. I've added a check that makes sure that the nucleotide corresponding to the `.` is lowercase and now the arrays/strings are of the same size. 

I ran the updated code on the battery of R2DT tests and it does not cause problems so it should be safe to merge as R2DT is probably the main user of this script.

Thank you again for writing this script in the first place because it really helps draw better diagrams where the placement of unpaired nucleotides matters.

----

Summary by Copilot: This pull request includes a significant update to the `read_structures` function in the `utils/infernal2mapping.py` file. The changes focus on improving the handling of insertions in sequence mappings.

Key changes include:

* [`utils/infernal2mapping.py`](diffhunk://#diff-024a5098d32a431cff2d3295e34655322a514026ab7f61585c76ae6dcf062b54L100-R108): Modified the `read_structures` function to correctly handle lowercase nucleotides and insertion characters ('.' and '~') by skipping them when constructing the `str` attribute of `tmp_s_s_m`.
