### PR TITLE
Render pseudoknot base pairs as per-bp connection lines

### DIFF
--- a/src/utils/document_writer.cpp
+++ b/src/utils/document_writer.cpp
@@ -646,15 +646,28 @@ std::string document_writer::render_pseudoknots(pseudoknots &pn) const
             ix_int++;
         }
 
-        vector<point> points;
-        for (line l:s.connecting_curve) {
-            points.push_back(l.first+ shift);
-//                oss << get_line_formatted(l.first, l.second, RGB::RED, opts_connection);
-        }
-        points.push_back(s.connecting_curve.back().second + shift);
+        // Emit one connection line PER base pair, using the explicit pair
+        // list maintained by the pseudoknots class. A pair belongs to this
+        // segment iff its first residue iterator lies within interval1
+        // (walking from interval1.first to interval1.second inclusive).
         opts_connection.clazz = string("pseudoknot_connection");
         opts_connection.id = s.get_id();
-        oss << get_polyline_formatted(points, RGB::GRAY, opts_connection);
+
+        for (auto& pkpair : pn.get_pairs()) {
+            bool in_segment = false;
+            auto it = s.interval1.first;
+            for (;;) {
+                if (it == pkpair.first) { in_segment = true; break; }
+                if (it == s.interval1.second) break;
+                ++it;
+            }
+            if (!in_segment) continue;
+
+            point p1 = pkpair.first->at(pkpair.first.label_index()).p + shift;
+            point p2 = pkpair.second->at(pkpair.second.label_index()).p + shift;
+            vector<point> pair_pts = { p1, p2 };
+            oss << get_polyline_formatted(pair_pts, RGB::GRAY, opts_connection);
+        }
 
 
 


### PR DESCRIPTION
Currently a pseudoknot segment is drawn with two stripes over its
paired-arm residues plus a single `pseudoknot_connection` polyline
summarizing the partnership as one diagonal line. This PR replaces
that single line with one line per base pair, matching the rendering
convention used for nested base pairs and making the per-pair
geometry visible.

Implementation iterates `pn.get_pairs()` (the explicit pair list
maintained by the `pseudoknots` class) and filters by segment.
Stripes are unchanged.

Behavior is default-on (no new CLI flag). Tested locally on a ZIKV
linear template with 4 pseudoknots (4+2+5+5 = 16 bp): output SVG has
16 `pseudoknot_connection` polylines instead of 4. Overlaps count
unchanged.

CC: @AntonPetrov who reviewed offline